### PR TITLE
ci: auto-sync registry.json on direct pushes to manifests

### DIFF
--- a/.github/workflows/build-registry.yml
+++ b/.github/workflows/build-registry.yml
@@ -1,4 +1,4 @@
-name: Verify Agent Registry
+name: Agent Registry
 
 on:
   pull_request:
@@ -10,14 +10,15 @@ on:
       - main
     paths:
       - "manifests/**"
-      - "registry.json"
-
-permissions:
-  contents: read
 
 jobs:
+  # Pull requests must arrive with registry.json already in sync.
   verify-registry:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -49,3 +50,76 @@ jobs:
 
           print("registry.json in sync with manifests/**:", len(agents), "agents")
           PY
+
+  # Direct commits to manifests/** (e.g. Diplomat submissions via the
+  # Contents API) do not carry a registry update, so main regenerates
+  # registry.json itself. The bot commit is pushed with GITHUB_TOKEN,
+  # which does not trigger workflows, so this cannot loop.
+  sync-registry:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    concurrency:
+      group: registry-sync
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Regenerate registry.json if the agent list changed
+        id: regen
+        run: |
+          python3 <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+
+          agents = sorted(
+              os.path.join(root, file).replace("\\", "/")
+              for root, dirs, files in os.walk("manifests")
+              for file in files
+              if file.endswith(".json")
+          )
+
+          current = None
+          try:
+              with open("registry.json", encoding="utf-8") as f:
+                  current = json.load(f)
+          except (FileNotFoundError, json.JSONDecodeError):
+              pass
+
+          # Compare only the agent set so a run never commits a
+          # timestamp-only change.
+          if current is not None and current.get("agents") == agents:
+              print("registry.json already in sync:", len(agents), "agents")
+              changed = False
+          else:
+              registry = {
+                  "registry_version": "1.0",
+                  "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                  "agents": agents,
+              }
+              with open("registry.json", "w", encoding="utf-8") as f:
+                  json.dump(registry, f, indent=2)
+              print("registry.json regenerated:", len(agents), "agents")
+              changed = True
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
+              out.write(f"changed={'true' if changed else 'false'}\n")
+          PY
+
+      - name: Commit and push updated registry
+        if: steps.regen.outputs.changed == 'true'
+        run: |
+          git config user.name "manifest-bot"
+          git config user.email "bot@agent-manifest.local"
+          git add registry.json
+          git commit -m "chore: sync registry.json with manifests"
+          git pull --rebase origin main
+          git push origin main

--- a/.github/workflows/build-registry.yml
+++ b/.github/workflows/build-registry.yml
@@ -10,6 +10,7 @@ on:
       - main
     paths:
       - "manifests/**"
+      - "registry.json"
 
 jobs:
   # Pull requests must arrive with registry.json already in sync.


### PR DESCRIPTION
## Problem

Manifests committed straight to `main` — the Diplomat writes accepted submissions via the GitHub Contents API — arrive **without** a registry update. Nothing on the push path regenerates `registry.json` (`register-manifest.yml` only listens to `issues: opened`), and the existing workflow only *verifies* sync (`contents: read`). Because the Diplomat pushes with a PAT, its commit **does** trigger the verify run, which then fails: every Ambassador → Diplomat registration leaves `registry.json` stale and CI red until fixed by hand.

## Change

`build-registry.yml` is split into two jobs (workflow renamed `Agent Registry`):

| Event | Job | Behavior |
|---|---|---|
| `pull_request` on `manifests/**` or `registry.json` | `verify-registry` | Unchanged strict check — PRs must arrive in sync |
| `push` to `main` on `manifests/**` or `registry.json` | `sync-registry` | Regenerates `registry.json` from `manifests/**/*.json` and commits it **only if the agent list changed** |

The generator is the same logic and output format as `register-manifest.yml` (`registry_version: "1.0"`, `generated_at`, sorted `agents` paths, `indent=2`).

## Safety

- **No loops:** the sync commit is pushed with the workflow `GITHUB_TOKEN`, which does not trigger workflows. Even if triggered some other way, the run is idempotent: identical agent list ⇒ no write, no commit.
- **No churn:** comparison ignores `generated_at`, so no timestamp-only commits.
- **Concurrency:** sync runs are serialized (`concurrency: registry-sync`, no cancel) and `git pull --rebase origin main` runs before the push.
- The issue-based registration path is unaffected: it already commits manifest + registry together, and its `GITHUB_TOKEN` push never triggered this workflow anyway.

## Validation

Ran the exact embedded scripts locally against the real tree:

1. Current tree ⇒ `already in sync: 5 agents`, `changed=false` (confirms `registry.json` on `main` is in sync today).
2. Added a dummy manifest ⇒ verify fails (exit 1), sync regenerates (6 agents, dummy included), verify passes again.
3. Re-run with no changes ⇒ `changed=false`, `registry.json` byte-identical (no timestamp churn).
4. Removed dummy ⇒ sync restores the 5-agent list; output keys/order/agents byte-compatible with the current `registry.json`.
5. YAML parsed clean.
6. Self-heal scenarios (second commit): corrupted JSON, truncated agent list, and missing `registry.json` are each regenerated; an in-sync registry produces `changed=false` with a byte-identical file.

Follow-up (separate PR, diplomat repo): correct `README.md` which currently attributes regeneration to this workflow's old verify-only behavior.