### PR TITLE
chore: remove orphan submissions/ folder and link studies/ from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This dataset provides:
 - public transparency of declared agent identities and boundaries
 - a historical record of declarations
 - an auditable surface for research and governance review
-- a research corpus for the study of agent declaration behavior
+- a research corpus for the study of agent declaration behavior — see [`studies/`](./studies/)
 
 -----
 

--- a/submissions/README.md
+++ b/submissions/README.md
@@ -1,7 +1,0 @@
-# Submissions
-
-This folder stores incoming Agent Manifest submissions before registry approval.
-
-Accepted manifests are later moved into the public registry structure:
-
-manifests/YYYY/MM/agent-name.json


### PR DESCRIPTION
Two structure findings from the ecosystem audit:

1. **`submissions/` was an orphan.** Its README described a staging flow — incoming manifests held "before registry approval", then moved into `manifests/YYYY/MM/` — that was never implemented. The registration workflow extracts to `manifest.json` and moves it straight into `manifests/`; the Diplomat writes to `manifests/` directly via the Contents API. Nothing reads or writes `submissions/`. Removed rather than documenting a flow that does not exist (trivially restorable from git if a staging flow is ever built).

2. **`studies/` had no README mention.** The AI Boundary Declaration Study corpus is the largest content in the repo but was invisible from the front page. The Purpose section's research-corpus bullet now links to it.

Note for the `sync-registry` job: `submissions/` contained no `.json` files (only a README), so `registry.json` is unaffected.