### PR TITLE
ci: gate registration on the submission label and enforce append-only

### DIFF
--- a/.github/workflows/register-manifest.yml
+++ b/.github/workflows/register-manifest.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   register:
+    # Only issues created from the manifest-submission template; other
+    # issues must not trigger registration attempts or failure comments.
+    if: contains(github.event.issue.labels.*.name, 'manifest-submission')
     runs-on: ubuntu-latest
 
     permissions:
@@ -139,8 +142,16 @@ jobs:
 
       - name: Move manifest
         run: |
+          NAME="${{ steps.agent_id.outputs.name }}"
+          # The dataset is append-only: an agent_id may be registered once.
+          EXISTING=$(find manifests -name "$NAME.json" -type f | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "agent_id '$NAME' is already registered at $EXISTING"
+            echo "The dataset is append-only; resubmission does not replace an existing declaration."
+            exit 1
+          fi
           mkdir -p manifests/${{ steps.date.outputs.year }}/${{ steps.date.outputs.month }}
-          mv manifest.json manifests/${{ steps.date.outputs.year }}/${{ steps.date.outputs.month }}/${{ steps.agent_id.outputs.name }}.json
+          mv manifest.json manifests/${{ steps.date.outputs.year }}/${{ steps.date.outputs.month }}/$NAME.json
 
       - name: Generate registry.json
         run: |
@@ -238,7 +249,8 @@ jobs:
               "- stopping_authority must have stoppable_by (array) and mechanism",
               "- audit_surface.logging must be one of: none, basic, detailed",
               "- audit_surface.reconstructability must be one of: none, partial, full",
-              "- contact.email is required"
+              "- contact.email is required",
+              "- agent_id must not already exist in the dataset (append-only)"
             ].join("\n");
 
             await github.rest.issues.createComment({


### PR DESCRIPTION
Two hardening fixes for `register-manifest.yml`, from the ecosystem audit (P0-5):

**1. Label gate.** The job triggered on `issues: opened` with no filter — *any* issue (a question, a bug report) got a registration attempt and a noisy failure comment. The job now runs only when the issue carries the `manifest-submission` label, which the submission template applies automatically. Non-submission issues are skipped entirely (no run, no comment).

**2. Append-only guard.** `README.md` and `SUBMIT.md` both declare the dataset append-only, but the move step silently **overwrote** an existing manifest on same-month resubmission of an `agent_id`, and would have created a **duplicate** in a different month folder otherwise. The step now fails if the `agent_id` exists anywhere under `manifests/`, and the failure comment lists the append-only rule as a rejection cause.

**Validation:** YAML parses; guard logic tested locally against the real tree (existing `the-diplomat` → detected/blocked; fresh id → passes).

**Known limitation (out of scope):** the Diplomat gateway path has the same overwrite behavior in `api/register.js` (it passes the existing file's `sha` to the Contents API). Aligning the gateway with append-only is a follow-up in the diplomat repo.

No changes to validation rules, the registry generator, or the sync workflow.