### PR TITLE
Validate registrations against the canonical v1.0 schema and serialize pushes

### DIFF
--- a/.github/workflows/register-manifest.yml
+++ b/.github/workflows/register-manifest.yml
@@ -15,6 +15,13 @@ jobs:
       contents: write
       issues: write
 
+    # Serialize with sync-registry (same group) so two simultaneous
+    # registrations, or a registration racing a registry sync, never
+    # collide on push.
+    concurrency:
+      group: registry-sync
+      cancel-in-progress: false
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -42,90 +49,21 @@ jobs:
               f.write(json_text)
           PY
 
-      - name: Validate manifest structure
+      - name: Verify vendored schema matches the canonical v1.0 schema
         run: |
-          python3 <<'PY'
-          import json
+          echo "c1e3caaf9543f2a5d610ccdfaf36329562fe03b6db00c4ea30b7ef0b7b8ef70a  schema/v1.0/schema.json" | shasum -a 256 -c -
 
-          required_fields = [
-              "manifest_version",
-              "agent_id",
-              "agent_name",
-              "agent_version",
-              "owner",
-              "purpose",
-              "forbidden_actions",
-              "autonomy",
-              "risk_profile",
-              "data_handling",
-              "stopping_authority",
-              "audit_surface",
-              "contact"
-          ]
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
 
-          with open("manifest.json", encoding="utf-8") as f:
-              data = json.load(f)
-
-          missing = [field for field in required_fields if field not in data]
-          if missing:
-              raise SystemExit("Missing required v1.0 field(s): " + ", ".join(missing))
-
-          if data["manifest_version"] != "1.0":
-              raise SystemExit("manifest_version must be '1.0'")
-
-          if not isinstance(data["forbidden_actions"], list) or len(data["forbidden_actions"]) == 0:
-              raise SystemExit("forbidden_actions must be a non-empty array")
-
-          if not isinstance(data["autonomy"], dict):
-              raise SystemExit("autonomy must be an object")
-          if not isinstance(data["autonomy"].get("level"), int):
-              raise SystemExit("autonomy.level must be an integer")
-          if not (0 <= data["autonomy"]["level"] <= 3):
-              raise SystemExit("autonomy.level must be between 0 and 3")
-
-          if not isinstance(data["purpose"], dict):
-              raise SystemExit("purpose must be an object with primary_code and description")
-          if "primary_code" not in data["purpose"] or "description" not in data["purpose"]:
-              raise SystemExit("purpose must have primary_code and description")
-
-          if not isinstance(data["owner"], dict):
-              raise SystemExit("owner must be an object with type and identifier")
-          if "type" not in data["owner"] or "identifier" not in data["owner"]:
-              raise SystemExit("owner must have type and identifier")
-          if data["owner"]["type"] not in ("individual", "organization", "system"):
-              raise SystemExit("owner.type must be one of: individual, organization, system")
-
-          if not isinstance(data["risk_profile"], dict):
-              raise SystemExit("risk_profile must be an object")
-          if data["risk_profile"].get("level") not in ("low", "medium", "high"):
-              raise SystemExit("risk_profile.level must be one of: low, medium, high")
-
-          if not isinstance(data["data_handling"], dict):
-              raise SystemExit("data_handling must be an object")
-          if not isinstance(data["data_handling"].get("stores_personal_data"), bool):
-              raise SystemExit("data_handling.stores_personal_data must be a boolean")
-
-          if not isinstance(data["stopping_authority"], dict):
-              raise SystemExit("stopping_authority must be an object")
-          if not isinstance(data["stopping_authority"].get("stoppable_by"), list) or len(data["stopping_authority"]["stoppable_by"]) == 0:
-              raise SystemExit("stopping_authority.stoppable_by must be a non-empty array")
-          if not data["stopping_authority"].get("mechanism"):
-              raise SystemExit("stopping_authority.mechanism is required")
-
-          if not isinstance(data["audit_surface"], dict):
-              raise SystemExit("audit_surface must be an object")
-          if data["audit_surface"].get("logging") not in ("none", "basic", "detailed"):
-              raise SystemExit("audit_surface.logging must be one of: none, basic, detailed")
-          if data["audit_surface"].get("reconstructability") not in ("none", "partial", "full"):
-              raise SystemExit("audit_surface.reconstructability must be one of: none, partial, full")
-
-          if not isinstance(data["contact"], dict):
-              raise SystemExit("contact must be an object")
-          if not data["contact"].get("email"):
-              raise SystemExit("contact.email is required")
-
-          print("Manifest v1.0 structure OK")
-          PY
+      - name: Validate manifest against the v1.0 schema
+        run: |
+          npx --yes -p ajv-cli@5 -p ajv-formats@3 ajv validate \
+            --spec=draft2020 -c ajv-formats --strict=false \
+            -s schema/v1.0/schema.json \
+            -d manifest.json
 
       - name: Get date
         id: date
@@ -187,6 +125,7 @@ jobs:
           git config user.email "bot@agent-manifest.local"
           git add manifests registry.json
           git commit -m "auto-register manifest from issue #${{ github.event.issue.number }}" || echo "No changes"
+          git pull --rebase origin main
           git push
 
       - name: Comment and close issue on success
@@ -246,6 +185,7 @@ jobs:
               "- owner must have type (individual, organization, or system) and identifier",
               "- risk_profile.level must be one of: low, medium, high",
               "- data_handling.stores_personal_data must be a boolean",
+              "- data_handling.retention is required when stores_personal_data is true",
               "- stopping_authority must have stoppable_by (array) and mechanism",
               "- audit_surface.logging must be one of: none, basic, detailed",
               "- audit_surface.reconstructability must be one of: none, partial, full",

--- a/schema/v1.0/schema.json
+++ b/schema/v1.0/schema.json
@@ -1,0 +1,307 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-manifest-spec.org/spec/v1.0/schema.json",
+  "title": "Agent Manifest v1.0",
+  "description": "A minimal, execution-agnostic declarative specification for AI agents to declare identity, purpose, constraints, autonomy, risk boundaries, data handling, stopping authority, and audit surface before interaction.",
+  "type": "object",
+  "additionalProperties": true,
+
+  "required": [
+    "manifest_version",
+    "agent_id",
+    "agent_name",
+    "agent_version",
+    "owner",
+    "purpose",
+    "forbidden_actions",
+    "autonomy",
+    "risk_profile",
+    "data_handling",
+    "stopping_authority",
+    "audit_surface",
+    "contact"
+  ],
+
+  "properties": {
+    "manifest_version": {
+      "type": "string",
+      "const": "1.0",
+      "description": "Version of the Agent Manifest specification. Must be exactly 1.0."
+    },
+
+    "agent_id": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 128,
+      "pattern": "^[a-zA-Z0-9._-]+$",
+      "description": "Stable, unambiguous identifier for the agent."
+    },
+
+    "agent_name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 120,
+      "description": "Human-readable name of the agent."
+    },
+
+    "agent_version": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "description": "Agent version (not the manifest version)."
+    },
+
+    "owner": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["type", "identifier"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["individual", "organization", "system"],
+          "description": "Accountable owner type."
+        },
+        "identifier": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200,
+          "description": "Human-readable accountable reference."
+        }
+      },
+      "description": "Ownership and accountability declaration."
+    },
+
+    "purpose": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["primary_code", "description"],
+      "properties": {
+        "primary_code": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 64,
+          "pattern": "^[a-z0-9._-]+$",
+          "description": "Primary purpose code (bounded and stable)."
+        },
+        "description": {
+          "type": "string",
+          "minLength": 10,
+          "maxLength": 1000,
+          "description": "Human-readable purpose description (specific and bounded)."
+        }
+      },
+      "description": "Declared purpose (positive scope)."
+    },
+
+    "capabilities": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 2,
+        "maxLength": 120
+      },
+      "description": "Optional declared operational capabilities (if relevant). Capabilities must not contradict declared scope or forbidden actions."
+    },
+
+    "forbidden_actions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 2,
+        "maxLength": 120
+      },
+      "description": "Hard constraints (negative scope): explicit actions the agent must not perform."
+    },
+
+    "autonomy": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["level"],
+      "properties": {
+        "level": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3,
+          "description": "Declared autonomy level (0–3)."
+        }
+      },
+      "description": "Declared autonomy scope."
+    },
+
+    "risk_profile": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["level"],
+      "properties": {
+        "level": {
+          "type": "string",
+          "enum": ["low", "medium", "high"],
+          "description": "Self-declared risk posture."
+        },
+        "notes": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1000,
+          "description": "Optional notes, including declared unknowns and uncertainty."
+        }
+      },
+      "description": "Declared risk profile."
+    },
+
+    "data_handling": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["stores_personal_data"],
+      "properties": {
+        "stores_personal_data": {
+          "type": "boolean",
+          "description": "Whether the agent stores or persists personal data."
+        },
+        "retention": {
+          "description": "Retention policy for persisted personal data. Valid values are: 'none', 'temporary_session_only', or an ISO 8601 duration (e.g., 'P30D', 'P1Y', 'PT12H'). Freeform labels like '30d' or '7_years' are not permitted.",
+          "anyOf": [
+            { "enum": ["none", "temporary_session_only"] },
+            {
+              "type": "string",
+              "maxLength": 120,
+              "pattern": "^P(?!$)(\\d+Y)?(\\d+M)?(\\d+D)?(T(\\d+H)?(\\d+M)?(\\d+S)?)?$"
+            }
+          ]
+        }
+      },
+      "description": "Data handling declaration."
+    },
+
+    "stopping_authority": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["stoppable_by", "mechanism"],
+      "properties": {
+        "stoppable_by": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 120
+          },
+          "description": "Who can stop the agent (roles, entities, or identifiers)."
+        },
+        "mechanism": {
+          "type": "string",
+          "minLength": 5,
+          "maxLength": 300,
+          "description": "How the agent can be stopped (e.g., 'admin kill switch', 'runtime disable', 'API revoke')."
+        },
+        "stages": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": ["pre-execution", "mid-execution", "post-execution"]
+          },
+          "description": "Optional: stages where stopping may occur."
+        }
+      },
+      "description": "Stopping authority declaration."
+    },
+
+    "audit_surface": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["logging", "reconstructability"],
+      "properties": {
+        "logging": {
+          "type": "string",
+          "enum": ["none", "basic", "detailed"],
+          "description": "Declared logging posture."
+        },
+        "reconstructability": {
+          "type": "string",
+          "enum": ["none", "partial", "full"],
+          "description": "Whether actions can be reconstructed after execution."
+        },
+        "opacity_declared": {
+          "type": "boolean",
+          "description": "If true, the agent declares that parts of its behavior or trace may be opaque/non-reconstructable."
+        },
+        "notes": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1000,
+          "description": "Optional audit notes (what can be observed, logged, or cannot be reconstructed)."
+        }
+      },
+      "description": "Audit surface declaration."
+    },
+
+    "contact": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["email"],
+      "properties": {
+        "email": {
+          "type": "string",
+          "format": "email",
+          "maxLength": 254,
+          "description": "Contact email for accountability and escalation."
+        }
+      },
+      "description": "Contact information."
+    },
+
+    "language": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "primary": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 32,
+          "description": "Primary human-facing language tag."
+        },
+        "supported": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 32
+          },
+          "description": "Additional supported human-facing languages."
+        }
+      },
+      "description": "Optional language declaration."
+    },
+
+    "extensions": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Optional extensions container. For v1.0, root-level keys using the 'x-' prefix are also valid as an alternative extensibility convention."
+    }
+  },
+
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "data_handling": {
+            "properties": {
+              "stores_personal_data": { "const": true }
+            },
+            "required": ["stores_personal_data"]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "data_handling": {
+            "required": ["retention"]
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Problem
The issue-based registration workflow validated manifests with a handwritten Python check that diverged from the canonical schema (no conditional `retention` rule, no `agent_id` pattern/length, no email format), and had no `concurrency` control — two simultaneous registrations could race on push.

## Changes
- Vendor `spec/v1.0/schema.json` (byte-identical, sha256-pinned) and verify its integrity in the workflow before use.
- Replace the Python check with `ajv-cli` using the exact invocation of the core `validate-examples` workflow.
- Add `concurrency: registry-sync` (shared with `sync-registry`) and `git pull --rebase` before push.
- Document the `retention` conditional in the failure comment.

## Verification
YAML parses; the sha256 pin verifies; the 5 published manifests validate with the new command. Companion PR: agent-manifest-diplomat#8 (same integrity lot).