### PR TITLE
docs: describe validation accurately; drop aspirational scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ All recorded manifests conform to the Agent Manifest v1.0 JSON Schema. Declarati
 ## What this is not
 
 - Not the normative specification. The spec lives at [agent-manifest-spec.org](https://agent-manifest-spec.org).
-- Not a validator. Schema validation happens at submission time inside the Diplomat.
+- Not a validator by itself. Schema validation happens at submission time on both registration paths: the Diplomat validates web submissions against the full v1.0 JSON Schema, and this repository's issue-based workflow validates `manifest-submission` issues against the same schema before appending.
 - Not a runtime enforcement layer. The dataset records declarations; it does not constrain behavior.
 - Not an adoption claim. Inclusion in the dataset reflects a declaration, not endorsement of the declaring system.
 

--- a/SUBMIT.md
+++ b/SUBMIT.md
@@ -16,7 +16,7 @@ Agent manifests can be submitted through GitHub Issues and will be automatically
 Once submitted:
 
 - The manifest JSON is extracted automatically.
-- The manifest is validated for all required v1.0 fields.
+- The manifest is validated against the canonical v1.0 JSON Schema.
 - The manifest is stored at `manifests/YYYY/MM/<agent_id>.json`.
 - The registry index (`registry.json`) is rebuilt.
 

--- a/SUBMIT.md
+++ b/SUBMIT.md
@@ -128,4 +128,4 @@ registry.json
 
 This repository stores declarations only.
 
-Validation, trust scoring, and compliance checks may be implemented in separate tools such as an Agent Manifest Validator.
+Structural validation is available offline via the [agent-manifest-cli](https://github.com/agent-manifest/agent-manifest-cli) tool, which checks manifests against the canonical v1.0 JSON Schema.


### PR DESCRIPTION
- README.md / SUBMIT.md: describe schema validation accurately for both registration paths.
- SUBMIT.md: removes the aspirational "trust scoring / compliance checks" note; points to the existing offline validation tool (agent-manifest-cli).

Documentation only — workflows, schema, registry.json, and stored manifests are untouched.